### PR TITLE
Feature request: show total count of social interactions instead of shares only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ lib-cov
 *.out
 *.pid
 *.gz
+*.swp
+.nvmrc
 
 pids
 logs

--- a/src/class-SH-Crafty-Social-Buttons-Admin.php
+++ b/src/class-SH-Crafty-Social-Buttons-Admin.php
@@ -218,6 +218,10 @@ class SH_Crafty_Social_Buttons_Admin {
 			array( $this, 'renderCheckbox' ), $page, $section,
 			array( 'show_count', __( 'Only displayed if service supports it.', $this->plugin_slug ) ) );
 
+		add_settings_field( 'show_count_total', __( 'Show total counts', $this->plugin_slug ),
+			array( $this, 'renderCheckbox' ), $page, $section,
+			array( 'show_count_total', __( 'Show total interaction count (shares, likes, comments) if services supports it (Facebook and Google).', $this->plugin_slug ) ) );
+
 		add_settings_field( 'email_body', __( 'Email text', $this->plugin_slug ),
 			array( $this, 'renderTextbox' ), $page, $section,
             array( 'email_body', __( 'Default Email text (user can override this)', $this->plugin_slug ) ) );
@@ -612,6 +616,7 @@ class SH_Crafty_Social_Buttons_Admin {
 			$settings['show_on_category']   = isset( $input['show_on_category'] );
 			$settings['show_on_archive']    = isset( $input['show_on_archive'] );
 			$settings['show_count']         = isset( $input['show_count'] );
+			$settings['show_count_total']   = isset( $input['show_count_total'] );
             $settings['twitter_show_title'] = isset( $input['twitter_show_title'] );
 
             // parse out our radio buttons, they are constrained so just take the values

--- a/src/class-SH-Crafty-Social-Buttons-Plugin.php
+++ b/src/class-SH-Crafty-Social-Buttons-Plugin.php
@@ -182,7 +182,7 @@ class SH_Crafty_Social_Buttons_Plugin {
 		$settings = $this->getSettings();
 
 		// only add javascript if post counts are to be shown
-		if ($settings['show_count']) {
+		if ($settings['show_count'] || $settings['show_count_total']) {
 
 			wp_enqueue_script( $this->plugin_slug . '-scripts',
 				plugins_url( 'js/public.min.js', __FILE__ ), array( 'jquery' ), $this->version, true );
@@ -276,7 +276,7 @@ class SH_Crafty_Social_Buttons_Plugin {
 				$file = include_once(plugin_dir_path(__FILE__) . "services/class-$class.php");
 
 				$service = new $class('share', $settings, '');
-				$count = intval($service->shareCount($url));
+				$count = intval($service->shareCount($url, $settings['show_count_total']));
 				$result->count = $count;
 				wp_die(json_encode($result));
 			}
@@ -323,6 +323,7 @@ class SH_Crafty_Social_Buttons_Plugin {
 			'share_caption_position'=> 'inline-block',
 			'share_alignment'		=> 'left',
 			'show_count'			=> false,
+			'show_count_total' => false,
             'open_in'			    => 'new_window',
             'popup'			        => false,
 			'email_body'			=> 'I thought you might like this: ',

--- a/src/class-SH-Crafty-Social-Buttons-Shortcode.php
+++ b/src/class-SH-Crafty-Social-Buttons-Shortcode.php
@@ -165,7 +165,7 @@ class SH_Crafty_Social_Buttons_Shortcode {
         $sizeKey            = substr(strval($settings[$type.'_image_size']),0,1);
 		$alignment          = $settings[$type.'_alignment'];
 		$caption_position   = $settings[$type.'_caption_position'];
-		$showCount          = $settings['show_count'];
+		$showCount          = $settings['show_count'] || $settings['show_count_total'];
 		
 		// use wordpress functions for page/post details
 

--- a/src/services/class-SH_Facebook.php
+++ b/src/services/class-SH_Facebook.php
@@ -32,15 +32,16 @@ class SH_Facebook extends SH_Social_Service {
 		return $url;
 	}
 
-	public function shareCount($url) {
+	public function shareCount($url, $showCountTotal) {
 		$response = wp_remote_get("http://api.facebook.com/method/links.getStats?urls=$url&format=json");
 		 if (is_wp_error($response)){
             // return zero if response is error
             return 0;
 		 } else {
+       $count_type = $showCountTotal ? 'total_count' : 'share_count';
 			 $json = json_decode($response['body'], true);
-			 if (isset($json[0]) && isset($json[0]['share_count'])) {
-				 return $json[0]['share_count'];
+			 if (isset($json[0]) && isset($json[0][$count_type])) {
+				 return $json[0][$count_type];
 			 }elseif (isset($json['shares'])) {
 				 return $json['shares'];
 			 } elseif (isset($json['likes'])) {

--- a/src/services/class-SH_Google.php
+++ b/src/services/class-SH_Google.php
@@ -35,7 +35,7 @@ class SH_Google extends SH_Social_Service {
 		return $url;
 	}
 
-	public function shareCount( $url ) {
+	public function shareCount( $url, $showCountTotal ) {
 		$args = array(
 			'method'    => 'POST',
 			'headers'   => array(
@@ -69,9 +69,22 @@ class SH_Google extends SH_Social_Service {
 			return 0;
 		} else {
 			$json = json_decode( $response['body'], true );
+      $count = intval( $json['result']['metadata']['globalCounts']['count'] );
+
+      // get also number of shares
+      // no official API hear so we just parse page. Can break at any time.
+      if ( $showCountTotal ) {
+          $shares_url = 'https://plus.google.com/ripple/details?hl=en&url='. $url;
+          $response = file_get_contents( $shares_url, false, NULL, 0, 1400 ); // read only start of file, we don't need all of it
+          $shares_match = preg_match('@([0-9]+) public shares@',$response,$matches);
+          if ( $matches && $matches[1]) {
+            $shares = $matches[1];
+            $count += intval($shares);
+          }
+      }
 
 			// return count of Google +1 for requsted URL
-			return intval( $json['result']['metadata']['globalCounts']['count'] );
+			return $count;
 		}
 	}
 


### PR DESCRIPTION
Some time ago your plugin shows (at least for facebook) total number of interactions which changed to shares only.

I think this should be configurable so here is pull request.

Looks like that this is relevant only for Facebook and Google. I split it to different commits as for Facebook I think this way is clean. 

But for Google, there is no official way how to get number of shares (you are in fact displaying number of +1 not shares). I'm simply parsing google+ page with url and fetch number of shares from there. I see 2 problems here: 1. it can stop working any time with change of that page. 2. I'm not sure if file_get_contents from remote page is supported everywhere and don't know how this will behave. First problem shouldn't be stopper as if it will case to work it simply will count as 0 and no "break".
